### PR TITLE
Efficient stack representation and syntax

### DIFF
--- a/src/Language/ELT0/Asm.hs
+++ b/src/Language/ELT0/Asm.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE BinaryLiterals #-}
+
 module Language.ELT0.Asm
   ( assemble
   , B.hPut
@@ -79,8 +81,8 @@ inst' (Or  r n1 n2) = rnn 4 r n1 n2
 inst' (Not r n)     = rn 5 r n
 inst' (Shl r n1 n2) = rnn 6 r n1 n2
 inst' (Shr r n1 n2) = rnn 7 r n1 n2
-inst' (Salloc w)    = word8 $ 11 .|. shiftL w 5
-inst' (Sfree  w)    = word8 $ 12 .|. shiftL w 5
+inst' (Salloc w)    = word8 $ 11 .|. shiftL (w .&. 0b111) 5
+inst' (Sfree  w)    = word8 $ 12 .|. shiftL (w .&. 0b111) 5
 inst' (Sld  r w)    = word8 13 <> reg r <> word8 w
 inst' _ = error "unreachable"
 

--- a/src/Language/ELT0/Asm.hs
+++ b/src/Language/ELT0/Asm.hs
@@ -68,7 +68,7 @@ opfs x b = b .|. setIfValue x 5
 inst :: Inst -> Recorder
 inst (Mov r o) = word8 (opfs o 0) <> reg r |- operand o
 inst (If r p)  = word8 (opfs p 8) <> reg r |- place p
-inst (Sst w o) = word8 (opfs o 14) <> word32BE w |- operand o
+inst (Sst w o) = word8 (opfs o 14) <> word8 w |- operand o
 inst i = fromBuilder $ inst' i
 
 inst' :: Inst -> Builder
@@ -81,7 +81,7 @@ inst' (Shl r n1 n2) = rnn 6 r n1 n2
 inst' (Shr r n1 n2) = rnn 7 r n1 n2
 inst' (Salloc w)    = word8 11 <> word32BE w
 inst' (Sfree  w)    = word8 12 <> word32BE w
-inst' (Sld  r w)    = word8 13 <> reg r <> word32BE w
+inst' (Sld  r w)    = word8 13 <> reg r <> word8 w
 inst' _ = error "unreachable"
 
 rnn :: Word8 -> Reg -> Numeric -> Numeric -> Builder

--- a/src/Language/ELT0/Asm.hs
+++ b/src/Language/ELT0/Asm.hs
@@ -79,8 +79,8 @@ inst' (Or  r n1 n2) = rnn 4 r n1 n2
 inst' (Not r n)     = rn 5 r n
 inst' (Shl r n1 n2) = rnn 6 r n1 n2
 inst' (Shr r n1 n2) = rnn 7 r n1 n2
-inst' (Salloc w)    = word8 11 <> word32BE w
-inst' (Sfree  w)    = word8 12 <> word32BE w
+inst' (Salloc w)    = word8 $ 11 .|. shiftL w 5
+inst' (Sfree  w)    = word8 $ 12 .|. shiftL w 5
 inst' (Sld  r w)    = word8 13 <> reg r <> word8 w
 inst' _ = error "unreachable"
 

--- a/src/Language/ELT0/Eval.hs
+++ b/src/Language/ELT0/Eval.hs
@@ -13,7 +13,7 @@ module Language.ELT0.Eval
   , Machine(..)
   ) where
 
-import Control.Arrow hiding (loop)
+import Control.Arrow
 import Control.Applicative
 import Control.Monad
 import Control.Monad.ST
@@ -87,7 +87,7 @@ data Machine s = Machine
 vector :: ST s (Vector s)
 vector = do
   a <- newArray_ (1, 0)
-  return $ Vector
+  return Vector
     { content = a
     , cap = 0
     , len = 0
@@ -174,7 +174,7 @@ runS c xs = runST $ do
   v <- runStack . stack <$> runMachine Machine
     { text = c
     , file = mempty
-    , stack = Stack $ Vector { content = inv, cap = l, len = l }
+    , stack = Stack Vector { content = inv, cap = l, len = l }
     }
   a <- unsafeFreeze $ content v
   return $ genericTake (len v) $ elems (a :: UArray Integer Word32)
@@ -186,10 +186,10 @@ runFS :: Code -> File -> [Word32] -> (File, [Word32])
 runFS c f xs = runST $ do
   let l = genericLength xs
   inv <- thaw (listArray (1, l) xs :: UArray Integer Word32)
-  m <- runMachine $ Machine
+  m <- runMachine Machine
     { text = c
     , file = f
-    , stack = Stack $ Vector { content = inv, cap = l, len = l }
+    , stack = Stack Vector { content = inv, cap = l, len = l }
     }
   a <- unsafeFreeze $ content $ runStack $ stack m
   return (file m, genericTake (len $ runStack $ stack m) $ elems (a :: UArray Integer Word32))

--- a/src/Language/ELT0/Parser.hs
+++ b/src/Language/ELT0/Parser.hs
@@ -180,13 +180,14 @@ word' = minimal f ["word"]
 word :: Minimal W
 word = W <$> word'
 
-liftedWord :: Minimal Word32
-liftedWord = minimal f ["lifted word"]
+liftedWord8 :: Minimal Word8
+liftedWord8 = minimal f ["lifted 8-bit integer"]
   where
     f (Digits w)
-      | w /= 0 = return w
       | w == 0 = Nothing
-    f MaxNum = return 0
+      | w <= 7 = return $ fromIntegral w
+      | w == 8 = return 0
+      | 9 <= w = Nothing
     f _ = Nothing
 
 word8 :: Minimal Word8
@@ -328,8 +329,8 @@ inst = do
     , f TShl "shl" $> rnn Shl
     , f TShr "shr" $> rnn Shr
     , f TIf  "if"  $> (If <$> fromMinimal register <*> fromMinimal place)
-    , f TSalloc "salloc" $> (Salloc <$> fromMinimal liftedWord)
-    , f TSfree  "sfree"  $> (Sfree <$> fromMinimal liftedWord)
+    , f TSalloc "salloc" $> (Salloc <$> fromMinimal liftedWord8)
+    , f TSfree  "sfree"  $> (Sfree <$> fromMinimal liftedWord8)
     , f TSld "sld" $> (Sld <$> fromMinimal register <*> fromMinimal word8)
     , f TSst "sst" $> (Sst <$> fromMinimal word8 <*> fromMinimal operand)
     ]

--- a/src/Language/ELT0/Parser.hs
+++ b/src/Language/ELT0/Parser.hs
@@ -180,6 +180,15 @@ word' = minimal f ["word"]
 word :: Minimal W
 word = W <$> word'
 
+liftedWord :: Minimal Word32
+liftedWord = minimal f ["lifted word"]
+  where
+    f (Digits w)
+      | w /= 0 = return w
+      | w == 0 = Nothing
+    f MaxNum = return 0
+    f _ = Nothing
+
 value :: Minimal Val
 value = Word <$> word -|- Label <$> label
 
@@ -311,8 +320,8 @@ inst = do
     , f TShl "shl" $> rnn Shl
     , f TShr "shr" $> rnn Shr
     , f TIf  "if"  $> (If <$> fromMinimal register <*> fromMinimal place)
-    , f TSalloc "salloc" $> (Salloc <$> fromMinimal word')
-    , f TSfree  "sfree"  $> (Sfree <$> fromMinimal word')
+    , f TSalloc "salloc" $> (Salloc <$> fromMinimal liftedWord)
+    , f TSfree  "sfree"  $> (Sfree <$> fromMinimal liftedWord)
     , f TSld "sld" $> (Sld <$> fromMinimal register <*> fromMinimal word')
     , f TSst "sst" $> (Sst <$> fromMinimal word' <*> fromMinimal operand)
     ]

--- a/src/Language/ELT0/Parser.hs
+++ b/src/Language/ELT0/Parser.hs
@@ -185,8 +185,7 @@ liftedWord8 = minimal f ["lifted 8-bit integer"]
   where
     f (Digits w)
       | w == 0 = Nothing
-      | w <= 7 = return $ fromIntegral w
-      | w == 8 = return 0
+      | w <= 8 = return $ fromIntegral w
       | 9 <= w = Nothing
     f _ = Nothing
 

--- a/src/Language/ELT0/Parser.hs
+++ b/src/Language/ELT0/Parser.hs
@@ -189,6 +189,14 @@ liftedWord = minimal f ["lifted word"]
     f MaxNum = return 0
     f _ = Nothing
 
+word8 :: Minimal Word8
+word8 = minimal f ["8-bit integer"]
+  where
+    f (Digits w)
+      | w <= fromIntegral (maxBound :: Word8) = return $ fromIntegral w
+      | otherwise = Nothing
+    f _ = Nothing
+
 value :: Minimal Val
 value = Word <$> word -|- Label <$> label
 
@@ -322,8 +330,8 @@ inst = do
     , f TIf  "if"  $> (If <$> fromMinimal register <*> fromMinimal place)
     , f TSalloc "salloc" $> (Salloc <$> fromMinimal liftedWord)
     , f TSfree  "sfree"  $> (Sfree <$> fromMinimal liftedWord)
-    , f TSld "sld" $> (Sld <$> fromMinimal register <*> fromMinimal word')
-    , f TSst "sst" $> (Sst <$> fromMinimal word' <*> fromMinimal operand)
+    , f TSld "sld" $> (Sld <$> fromMinimal register <*> fromMinimal word8)
+    , f TSst "sst" $> (Sst <$> fromMinimal word8 <*> fromMinimal operand)
     ]
   maybe (return Nothing) (fmap Just) ma
   where

--- a/src/Language/ELT0/Parser/Lexer.hs
+++ b/src/Language/ELT0/Parser/Lexer.hs
@@ -192,12 +192,12 @@ lexWord p x = do
   b <- lift notFollowedByLetter
   unless b $
     lift getPos >>= throwE . FollowedByAlpha (x : s)
-  fmap (at p) $ lexDigits p (x : s) >>= validImm32 p
+  fmap (at p . Digits) $ lexDigits p (x : s) >>= validImm32 p
 
 -- Precondition: @n >= 0@ must hold.
-validImm32 :: Position -> Integer -> Lexer Token
-validImm32 p n | n > 1 + toInteger (maxBound :: Word32) = throwE $ OverflowImm32 n p
-validImm32 _ n = return $ Digits $ fromInteger n
+validImm32 :: Position -> Integer -> Lexer Word32
+validImm32 p n | n > toInteger (maxBound :: Word32) = throwE $ OverflowImm32 n p
+validImm32 _ n = return $ fromInteger n
 
 notFollowedByLetter :: Stream Bool
 notFollowedByLetter = Stream

--- a/src/Language/ELT0/Parser/Lexer.hs
+++ b/src/Language/ELT0/Parser/Lexer.hs
@@ -61,7 +61,6 @@ data Token
   | Jmp -- ^ a `jmp` mnemonic
   | Halt -- ^ a `halt` mnemonic
   | Digits Word32 -- ^ a word
-  | MaxNum -- ^ @ 2^32 @
   | RegToken Word8 -- ^ a register
   | Colon
   | LBrace -- ^ a left brace
@@ -198,7 +197,6 @@ lexWord p x = do
 -- Precondition: @n >= 0@ must hold.
 validImm32 :: Position -> Integer -> Lexer Token
 validImm32 p n | n > 1 + toInteger (maxBound :: Word32) = throwE $ OverflowImm32 n p
-validImm32 _ n | n == 1 + toInteger (maxBound :: Word32) = return $ MaxNum
 validImm32 _ n = return $ Digits $ fromInteger n
 
 notFollowedByLetter :: Stream Bool

--- a/src/Language/ELT0/Program.hs
+++ b/src/Language/ELT0/Program.hs
@@ -67,8 +67,8 @@ data Inst
   | If  Reg Place
   | Salloc Word32
   | Sfree  Word32
-  | Sld    Reg Word32
-  | Sst    Word32 Operand -- Allow labels to be used with the "sst" instruction.
+  | Sld    Reg Word8
+  | Sst    Word8 Operand -- Allow labels to be used with the "sst" instruction.
   deriving (Eq, Show)
 
 newtype Program = Program [Block]

--- a/src/Language/ELT0/Program.hs
+++ b/src/Language/ELT0/Program.hs
@@ -65,8 +65,8 @@ data Inst
   | Shl Reg Numeric Numeric
   | Shr Reg Numeric Numeric
   | If  Reg Place
-  | Salloc Word32
-  | Sfree  Word32
+  | Salloc Word8
+  | Sfree  Word8
   | Sld    Reg Word8
   | Sst    Word8 Operand -- Allow labels to be used with the "sst" instruction.
   deriving (Eq, Show)

--- a/src/Language/ELT0/Program.hs
+++ b/src/Language/ELT0/Program.hs
@@ -65,8 +65,8 @@ data Inst
   | Shl Reg Numeric Numeric
   | Shr Reg Numeric Numeric
   | If  Reg Place
-  | Salloc Word8
-  | Sfree  Word8
+  | Salloc Word8 -- 1 to 8
+  | Sfree  Word8 -- 1 to 8
   | Sld    Reg Word8
   | Sst    Word8 Operand -- Allow labels to be used with the "sst" instruction.
   deriving (Eq, Show)

--- a/src/Language/ELT0/Type.hs
+++ b/src/Language/ELT0/Type.hs
@@ -65,7 +65,7 @@ data TypeError
   -- |
   -- @ShortStack w l@ states that it is not possible to access @w@ slots of the
   -- stack whose length is @l@.
-  | ShortStack Word32 Word32
+  | ShortStack Word32 Integer
   | AccessToNonsense Word8 Stack
   | UnboundLabel String
   | UnboundRegister Reg
@@ -178,11 +178,11 @@ match e1 e2 = if e1 <: e2
   then return ()
   else liftEither $ Left $ Mismatch e1 e2
 
-sfree :: Word32 -> TypeChecker ()
+sfree :: Word8 -> TypeChecker ()
 sfree w = do
   s <- lift $ gets stack
-  let l = genericLength s
-  guardE (ShortStack w l) $ w <= l
+  let l = genericLength s :: Integer
+  guardE (ShortStack (fromIntegral w) l) $ fromIntegral w <= l
   putStack $ genericDrop w s
 
 putStack :: Stack -> TypeChecker ()

--- a/test/Language/ELT0/EvalSpec.hs
+++ b/test/Language/ELT0/EvalSpec.hs
@@ -73,8 +73,8 @@ spec = do
       runStack (code [11, 0, 0, 0, 2, 11, 0, 0, 0, 5, 10]) [] `shouldBe` replicate 7 0
 
       -- "sfree"
-      runStack (code [12, 0, 0, 0, 0, 10]) []                            `shouldBe` []
-      runStack (code [12, 0, 0, 0, 0, 10]) [5]                           `shouldBe` [5]
+      --runStack (code [12, 0, 0, 0, 0, 10]) (replicate (2^32) 0)          `shouldBe` []
+      --runStack (code [12, 0, 0, 0, 0, 10]) (replicate (2^32 + 1) 5)      `shouldBe` [5]
       runStack (code [12, 0, 0, 0, 1, 10]) [12]                          `shouldBe` []
       runStack (code [12, 0, 0, 0, 4, 10]) [12, 1, 3, 18, 8031, 23, 922] `shouldBe` [8031, 23, 922]
 

--- a/test/Language/ELT0/EvalSpec.hs
+++ b/test/Language/ELT0/EvalSpec.hs
@@ -81,13 +81,13 @@ spec = do
       let f rf s (Machine _ rf0 s0) = rf0 == rf && s0 == s
 
       -- "sld"
-      runMachine (Machine (code [13, 12, 0, 0, 0, 0, 10]) Map.empty [555]) `shouldSatisfy` f (Map.singleton 12 555) [555]
-      runMachine (Machine (code [13, 12, 0, 0, 0, 1, 10]) Map.empty [7, 3]) `shouldSatisfy` f (Map.singleton 12 3) [7, 3]
+      runMachine (Machine (code [13, 12, 0, 10]) Map.empty [555]) `shouldSatisfy` f (Map.singleton 12 555) [555]
+      runMachine (Machine (code [13, 12, 1, 10]) Map.empty [7, 3]) `shouldSatisfy` f (Map.singleton 12 3) [7, 3]
 
       -- "sst"
       let rf = Map.singleton 12 333 in
-        runMachine (Machine (code [14, 0, 0, 0, 0, 12, 10]) rf [0]) `shouldSatisfy` f rf [333]
+        runMachine (Machine (code [14, 0, 12, 10]) rf [0]) `shouldSatisfy` f rf [333]
       let rf = Map.singleton 5 9 in
-        runMachine (Machine (code [14, 0, 0, 0, 7, 5, 10]) rf [0, 1, 4, 8, 11, 3, 2, 0, 1]) `shouldSatisfy` f rf [0, 1, 4, 8, 11, 3, 2, 9, 1]
+        runMachine (Machine (code [14, 7, 5, 10]) rf [0, 1, 4, 8, 11, 3, 2, 0, 1]) `shouldSatisfy` f rf [0, 1, 4, 8, 11, 3, 2, 9, 1]
       let rf = Map.empty in
-        runMachine (Machine (code [0b00101110, 0, 0, 0, 1, 0, 0, 1, 123, 10]) rf [2, 4]) `shouldSatisfy` f rf [2, 379]
+        runMachine (Machine (code [0b00101110, 1, 0, 0, 1, 123, 10]) rf [2, 4]) `shouldSatisfy` f rf [2, 379]

--- a/test/Language/ELT0/EvalSpec.hs
+++ b/test/Language/ELT0/EvalSpec.hs
@@ -67,16 +67,16 @@ spec = do
       run (code [0b00101001, 0, 0, 0, 8, 0xff, 0xff, 0b00100000, 8, 0, 0, 0, 230, 10]) `shouldBe` Map.singleton 8 230
 
       -- "salloc"
-      run (code [11, 0, 0, 0, 1, 10])                     `shouldBe` Map.empty
-      runS (code [11, 0, 0, 0, 1, 10]) []                 `shouldBe` [0]
-      runS (code [11, 0, 0, 0, 4, 10]) []                 `shouldBe` [0, 0, 0, 0]
-      runS (code [11, 0, 0, 0, 2, 11, 0, 0, 0, 5, 10]) [] `shouldBe` replicate 7 0
+      run (code [0b00101011, 10])                 `shouldBe` Map.empty
+      runS (code [0b00101011, 10]) []             `shouldBe` [0]
+      runS (code [0b10001011, 10]) []             `shouldBe` [0, 0, 0, 0]
+      runS (code [0b01001011, 0b10101011, 10]) [] `shouldBe` replicate 7 0
 
       -- "sfree"
       --runS (code [12, 0, 0, 0, 0, 10]) (replicate (2^32) 0)          `shouldBe` []
       --runS (code [12, 0, 0, 0, 0, 10]) (replicate (2^32 + 1) 5)      `shouldBe` [5]
-      runS (code [12, 0, 0, 0, 1, 10]) [12]                          `shouldBe` []
-      runS (code [12, 0, 0, 0, 4, 10]) [12, 1, 3, 18, 8031, 23, 922] `shouldBe` [12, 1, 3]
+      runS (code [0b00101100, 10]) [12]                          `shouldBe` []
+      runS (code [0b10001100, 10]) [12, 1, 3, 18, 8031, 23, 922] `shouldBe` [12, 1, 3]
 
       -- "sld"
       runFS (code [13, 12, 0, 10]) Map.empty [555]  `shouldBe` (Map.singleton 12 555, [555])

--- a/test/Language/ELT0/EvalSpec.hs
+++ b/test/Language/ELT0/EvalSpec.hs
@@ -67,27 +67,25 @@ spec = do
       run (code [0b00101001, 0, 0, 0, 8, 0xff, 0xff, 0b00100000, 8, 0, 0, 0, 230, 10]) `shouldBe` Map.singleton 8 230
 
       -- "salloc"
-      run (code [11, 0, 0, 0, 1, 10])                         `shouldBe` Map.empty
-      runStack (code [11, 0, 0, 0, 1, 10]) []                 `shouldBe` [0]
-      runStack (code [11, 0, 0, 0, 4, 10]) []                 `shouldBe` [0, 0, 0, 0]
-      runStack (code [11, 0, 0, 0, 2, 11, 0, 0, 0, 5, 10]) [] `shouldBe` replicate 7 0
+      run (code [11, 0, 0, 0, 1, 10])                     `shouldBe` Map.empty
+      runS (code [11, 0, 0, 0, 1, 10]) []                 `shouldBe` [0]
+      runS (code [11, 0, 0, 0, 4, 10]) []                 `shouldBe` [0, 0, 0, 0]
+      runS (code [11, 0, 0, 0, 2, 11, 0, 0, 0, 5, 10]) [] `shouldBe` replicate 7 0
 
       -- "sfree"
-      --runStack (code [12, 0, 0, 0, 0, 10]) (replicate (2^32) 0)          `shouldBe` []
-      --runStack (code [12, 0, 0, 0, 0, 10]) (replicate (2^32 + 1) 5)      `shouldBe` [5]
-      runStack (code [12, 0, 0, 0, 1, 10]) [12]                          `shouldBe` []
-      runStack (code [12, 0, 0, 0, 4, 10]) [12, 1, 3, 18, 8031, 23, 922] `shouldBe` [8031, 23, 922]
-
-      let f rf s (Machine _ rf0 s0) = rf0 == rf && s0 == s
+      --runS (code [12, 0, 0, 0, 0, 10]) (replicate (2^32) 0)          `shouldBe` []
+      --runS (code [12, 0, 0, 0, 0, 10]) (replicate (2^32 + 1) 5)      `shouldBe` [5]
+      runS (code [12, 0, 0, 0, 1, 10]) [12]                          `shouldBe` []
+      runS (code [12, 0, 0, 0, 4, 10]) [12, 1, 3, 18, 8031, 23, 922] `shouldBe` [12, 1, 3]
 
       -- "sld"
-      runMachine (Machine (code [13, 12, 0, 10]) Map.empty [555]) `shouldSatisfy` f (Map.singleton 12 555) [555]
-      runMachine (Machine (code [13, 12, 1, 10]) Map.empty [7, 3]) `shouldSatisfy` f (Map.singleton 12 3) [7, 3]
+      runFS (code [13, 12, 0, 10]) Map.empty [555]  `shouldBe` (Map.singleton 12 555, [555])
+      runFS (code [13, 12, 1, 10]) Map.empty [7, 3] `shouldBe` (Map.singleton 12 7, [7, 3])
 
       -- "sst"
       let rf = Map.singleton 12 333 in
-        runMachine (Machine (code [14, 0, 12, 10]) rf [0]) `shouldSatisfy` f rf [333]
+        runFS (code [14, 0, 12, 10]) rf [0] `shouldBe` (rf, [333])
       let rf = Map.singleton 5 9 in
-        runMachine (Machine (code [14, 7, 5, 10]) rf [0, 1, 4, 8, 11, 3, 2, 0, 1]) `shouldSatisfy` f rf [0, 1, 4, 8, 11, 3, 2, 9, 1]
+        runFS (code [14, 7, 5, 10]) rf [0, 1, 4, 8, 11, 3, 2, 0, 1] `shouldBe` (rf, [0, 9, 4, 8, 11, 3, 2, 0, 1])
       let rf = Map.empty in
-        runMachine (Machine (code [0b00101110, 1, 0, 0, 1, 123, 10]) rf [2, 4]) `shouldSatisfy` f rf [2, 379]
+        runFS (code [0b00101110, 1, 0, 0, 1, 123, 10]) rf [2, 4] `shouldBe` (rf, [379, 4])

--- a/test/Language/ELT0/EvalSpec.hs
+++ b/test/Language/ELT0/EvalSpec.hs
@@ -73,8 +73,8 @@ spec = do
       runS (code [0b01001011, 0b10101011, 10]) [] `shouldBe` replicate 7 0
 
       -- "sfree"
-      --runS (code [12, 0, 0, 0, 0, 10]) (replicate (2^32) 0)          `shouldBe` []
-      --runS (code [12, 0, 0, 0, 0, 10]) (replicate (2^32 + 1) 5)      `shouldBe` [5]
+      runS (code [0b00001100, 10]) [12, 1, 3, 18, 831, 23, 2, 1] `shouldBe` []
+      runS (code [0b00001100, 10]) [12, 1, 3, 3, 9, 5, 23, 2, 1] `shouldBe` [12]
       runS (code [0b00101100, 10]) [12]                          `shouldBe` []
       runS (code [0b10001100, 10]) [12, 1, 3, 18, 8031, 23, 922] `shouldBe` [12, 1, 3]
 


### PR DESCRIPTION
- For evaluation (not type checking), use mutable, unboxed arrays to represent stacks.
- Restrict syntax related to stack operations so that resulting machine code will be shorter.

This change solves the problems in #2. Consult #2 for the details.