### PR TITLE
Stack polymorphism

### DIFF
--- a/src/Language/ELT0/Parser.hs
+++ b/src/Language/ELT0/Parser.hs
@@ -288,7 +288,7 @@ slot = do
   a
 
 slotM :: Minimal (Parser (Slot Type))
-slotM = fmap (Slot . Just) <$> typeM -|- ns $> return (Slot Nothing)
+slotM = fmap Slot <$> typeM -|- ns $> return Nonsense -|- return . StackVar <$> tyVar
 
 ns :: Minimal ()
 ns = token NS $ show "NS"

--- a/src/Language/ELT0/Program.hs
+++ b/src/Language/ELT0/Program.hs
@@ -108,7 +108,7 @@ type Stack = [Slot Type]
 data Slot a
   = Nonsense
   | Slot a
-  | StackVar String
+  | StackVar String Int
   deriving (Eq, Show)
 
 class Display a where
@@ -170,7 +170,7 @@ instance Display a => Display (Slot a) where
   -- "NS" stands for nonsense; see [Stack-Based Typed Assembly Language] (1998) by Morrisett et al.
   displayS Nonsense = showString "NS"
   displayS (Slot x) = displayS x
-  displayS (StackVar s) = showString s
+  displayS (StackVar s _) = showString s
 
 instance Display Env where
   displayS e = showString "Code" . b (binding e) . f (file e) . s (stack e)

--- a/src/Language/ELT0/Program.hs
+++ b/src/Language/ELT0/Program.hs
@@ -105,7 +105,10 @@ type File = Map.Map Reg Type
 
 type Stack = [Slot Type]
 
-newtype Slot a = Slot { runSlot :: Maybe a }
+data Slot a
+  = Nonsense
+  | Slot a
+  | StackVar String
   deriving (Eq, Show)
 
 class Display a where
@@ -165,9 +168,9 @@ instance Display Type where
 
 instance Display a => Display (Slot a) where
   -- "NS" stands for nonsense; see [Stack-Based Typed Assembly Language] (1998) by Morrisett et al.
-  displayS s = case runSlot s of
-    Nothing -> showString "NS"
-    Just x -> displayS x
+  displayS Nonsense = showString "NS"
+  displayS (Slot x) = displayS x
+  displayS (StackVar s) = showString s
 
 instance Display Env where
   displayS e = showString "Code" . b (binding e) . f (file e) . s (stack e)

--- a/src/Language/ELT0/Type.hs
+++ b/src/Language/ELT0/Type.hs
@@ -198,7 +198,6 @@ isInt _ = False
 guardInt :: Typed a Type => a -> TypeChecker ()
 guardInt n = typeOf n >>= guardE . MustInt <*> isInt
 
--- Note: if allowed quantification over 'Code', 'fromCode' should return also polymorphic 'Code'.
 fromCode :: Type -> Either TypeError Env
 fromCode (Code e) = return e
 fromCode Int      = Left $ MustCode Int

--- a/src/Language/ELT0/Type.hs
+++ b/src/Language/ELT0/Type.hs
@@ -34,7 +34,7 @@ fromProgram (Program bs) = foldrM p Map.empty bs
     p (Block l e _ _) h = return $ Map.insert l (Code e) h
 
 isStackVar :: Slot a -> Bool
-isStackVar (StackVar _) = True
+isStackVar (StackVar _ _) = True
 isStackVar _ = False
 
 lenInteger :: Stack -> Integer
@@ -55,7 +55,7 @@ nth w s = req w s >>= f . snd
     f (x : _) = case x of
       Slot t -> return t
       Nonsense -> Left $ AccessToNonsense w s
-      StackVar _ -> Left $ UnderStackVar w s
+      StackVar _ _ -> Left $ UnderStackVar w s
 
 headMay :: [a] -> Maybe a
 headMay [] = Nothing

--- a/test/Language/ELT0/AsmSpec.hs
+++ b/test/Language/ELT0/AsmSpec.hs
@@ -12,11 +12,11 @@ spec = do
   describe "assemble" $
     it "assembles a program" $ do
       let f = resolve . assemble' . Program
-      let block l is mp = Block l env is mp
+      let block l is mp = Block l env is $ flip STApp [] <$> mp
       f [block "" [] Nothing]                                        `shouldBe` [10]
       f [block "" [] (Just $ registerP 5)]                           `shouldBe` [0b00001001, 5]
       f [block "" [] (Just $ labelP "")]                             `shouldBe` [0b00101001, 0, 0, 0, 1]
       f [block "x" [] (Just $ labelP "x")]                           `shouldBe` [0b00101001, 0, 0, 0, 1]
       f [block "" [] (Just $ labelP "x"), block "x" [] Nothing]      `shouldBe` [0b00101001, 0, 0, 0, 6, 10]
-      f [block "" [Reg 3 `Mov` registerO 4] Nothing]                 `shouldBe` [0b00000000, 3, 4, 10]
+      f [block "" [Reg 3 `Mov` STApp (registerO 4) []] Nothing]      `shouldBe` [0b00000000, 3, 4, 10]
       f [block "" [Shr (Reg 0) (registerN 40) $ wordN 1024] Nothing] `shouldBe` [0b01000111, 0, 40, 0, 0, 0b0100, 0, 10]

--- a/test/Language/ELT0/ProgramSpec.hs
+++ b/test/Language/ELT0/ProgramSpec.hs
@@ -8,6 +8,6 @@ spec :: Spec
 spec = do
   describe "display" $
     it "displays a data" $ do
-      let i = Reg 0 `Mov` wordO 123
+      let i = Reg 0 `Mov` STApp (wordO 123) []
       display i                           `shouldBe` "mov R0 123"
       display (Block "x" env [i] Nothing) `shouldBe` "x Code:\nmov R0 123\nhalt"

--- a/test/Language/ELT0/TypeSpec.hs
+++ b/test/Language/ELT0/TypeSpec.hs
@@ -11,18 +11,19 @@ spec :: Spec
 spec = do
   describe "program" $
     it "typechecks a program" $ do
-      let block l is mp = Block l env is mp
+      let block l is mp = Block l env is $ flip STApp [] <$> mp
+      let f x y = STApp (x y) []
 
       Program []                                       `program` mempty                      `shouldBe` return ()
       Program [block "" [] Nothing]                    `program` Map.singleton "" (Code env) `shouldBe` return ()
-      Program [block "" [Reg 1 `Mov` wordO 9] Nothing] `program` Map.singleton "" (Code env) `shouldBe` return ()
+      Program [block "" [Reg 1 `Mov` f wordO 9] Nothing] `program` Map.singleton "" (Code env) `shouldBe` return ()
 
       let e0 = env { file = Map.singleton (Reg 0) Int }
       let e = env { file = Map.fromList [(Reg 0, Int), (Reg 1, Int)] }
-      Program [block "" [Reg 0 `Mov` wordO 5] $ return $ labelP "x"] `program` Map.fromList [("", Code env), ("x", (Code e0))] `shouldBe` return ()
-      Program [block "" [Reg 0 `Mov` wordO 5, Reg 1 `Mov` wordO 6] $ return $ labelP "x"] `program` Map.fromList [("", Code env), ("x", (Code e0))] `shouldBe` return ()
-      Program [block "" [Reg 0 `Mov` wordO 5, Reg 1 `Mov` wordO 6] $ return $ labelP "x"] `program` Map.fromList [("", Code env), ("x", (Code e))] `shouldBe` return ()
+      Program [block "" [Reg 0 `Mov` f wordO 5] $ return $ labelP "x"] `program` Map.fromList [("", Code env), ("x", (Code e0))] `shouldBe` return ()
+      Program [block "" [Reg 0 `Mov` f wordO 5, Reg 1 `Mov` f wordO 6] $ return $ labelP "x"] `program` Map.fromList [("", Code env), ("x", (Code e0))] `shouldBe` return ()
+      Program [block "" [Reg 0 `Mov` f wordO 5, Reg 1 `Mov` f wordO 6] $ return $ labelP "x"] `program` Map.fromList [("", Code env), ("x", (Code e))] `shouldBe` return ()
 
-      Program [block "" [Reg 0 `Mov` wordO 5] $ return $ labelP "x"] `program` Map.fromList [("", Code env), ("x", (Code e))] `shouldBe` Left (Mismatch e0 e)
+      Program [block "" [Reg 0 `Mov` f wordO 5] $ return $ labelP "x"] `program` Map.fromList [("", Code env), ("x", (Code e))] `shouldBe` Left (Mismatch e0 e)
 
-      Program [block "" [Reg 1 `Mov` registerO 2] Nothing] `program` Map.singleton "" (Code env) `shouldBe` Left (UnboundRegister $ Reg 2)
+      Program [block "" [Reg 1 `Mov` f registerO 2] Nothing] `program` Map.singleton "" (Code env) `shouldBe` Left (UnboundRegister $ Reg 2)


### PR DESCRIPTION
Support stack polymorphism.

The syntax for stack polymorphism is conservative in terms of type checking. No type reconstruction is performed. Thus programmers must explicitly annotate type information even if the type reconstruction problem is obvious.

By this PR, the following trivial code become well-typed:

```
main Code:
salloc 2
sst 0 43
sst 1 51
mov R0 end [[Int]]
jmp cont [[Int, Int]]

cont Code b{R0: Code[b]}[b]:
jmp R0

end Code a[Int, a]:
sld R5 0
sfree 2
halt
```